### PR TITLE
Quality: error rate map fixes.

### DIFF
--- a/seq/seq.go
+++ b/seq/seq.go
@@ -15,12 +15,14 @@ var defaultBytesBufferSize = 10 << 20
 
 var bufferedByteSliceWrapper *byteutil.BufferedByteSliceWrapper
 
-var QUAL_MAP [93]float64
+var QUAL_MAP [256]float64
 
 func initQualMap() {
 	for i, _ := range QUAL_MAP {
 		QUAL_MAP[i] = math.Pow(10, float64(i)/-10)
 	}
+	QUAL_MAP[255] = 1.0
+
 }
 
 func init() {


### PR DESCRIPTION
Hello, 

Here is a small fix:
Extended the quality: error rate map table to length 256. Set the value
for 255 to 1.0 to be in line with the BAM format specification. That means that BAM records with empty qualities will have base qualities set to zero. This should probably trigger a minor seqkit release.

Best,
Botond