### PR TITLE
Use ASCIISet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/cznic/sortutil v0.0.0-20181122101858-f5f958428db8
 	github.com/edsrzf/mmap-go v1.0.0
+	github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab
 	github.com/shenwei356/breader v0.3.2
 	github.com/shenwei356/kmers v0.1.0
 	github.com/shenwei356/util v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5Jflh
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab h1:h1UgjJdAAhj+uPL68n7XASS6bU+07ZX1WJvVS2eyoeY=
+github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/seq/alphabet.go
+++ b/seq/alphabet.go
@@ -1,4 +1,5 @@
-/*Package seq defines a *Seq* type, and provides some basic operations of sequence,
+/*
+Package seq defines a *Seq* type, and provides some basic operations of sequence,
 like validation of DNA/RNA/Protein sequence and getting reverse complement sequence.
 
 This package was inspired by
@@ -7,7 +8,6 @@ This package was inspired by
 IUPAC nucleotide code: ACGTURYSWKMBDHVN
 
 http://droog.gs.washington.edu/parc/images/iupac.html
-
 
 	code	base	Complement
 	A	A	T
@@ -65,13 +65,12 @@ IUPAC amino acid code
 
 Reference:
 
-	1. http://www.bioinformatics.org/sms/iupac.html
-	2. http://www.dnabaser.com/articles/IUPAC%20ambiguity%20codes.html
-	3. http://www.bioinformatics.org/sms2/iupac.html
-	4. http://www.matrixscience.com/blog/non-standard-amino-acid-residues.html
-	5. http://www.sbcs.qmul.ac.uk/iupac/AminoAcid/A2021.html#AA21
-	6. https://en.wikipedia.org/wiki/Amino_acid
-
+ 1. http://www.bioinformatics.org/sms/iupac.html
+ 2. http://www.dnabaser.com/articles/IUPAC%20ambiguity%20codes.html
+ 3. http://www.bioinformatics.org/sms2/iupac.html
+ 4. http://www.matrixscience.com/blog/non-standard-amino-acid-residues.html
+ 5. http://www.sbcs.qmul.ac.uk/iupac/AminoAcid/A2021.html#AA21
+ 6. https://en.wikipedia.org/wiki/Amino_acid
 */
 package seq
 
@@ -81,10 +80,12 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/elliotwutingfeng/asciiset"
 	"github.com/shenwei356/util/byteutil"
 )
 
-/*Alphabet could be defined. Attention that,
+/*
+Alphabet could be defined. Attention that,
 **the letters are case sensitive**.
 
 For example, DNA:
@@ -95,7 +96,6 @@ For example, DNA:
 		[]byte("tgcaTGCA"),
 		[]byte(" -"),
 		[]byte("nN"))
-
 */
 type Alphabet struct {
 	t         string
@@ -327,15 +327,15 @@ func (a *Alphabet) PairLetter(b byte) (byte, error) {
 	return p, nil
 }
 
-/*Four types of alphabets are pre-defined:
+/*
+Four types of alphabets are pre-defined:
 
-  DNA           Deoxyribonucleotide code
-  DNAredundant  DNA + Ambiguity Codes
-  RNA           Oxyribonucleotide code
-  RNAredundant  RNA + Ambiguity Codes
-  Protein       Amino Acide single-letter Code
-  Unlimit       Self-defined, including all 26 English letters
-
+	DNA           Deoxyribonucleotide code
+	DNAredundant  DNA + Ambiguity Codes
+	RNA           Oxyribonucleotide code
+	RNAredundant  RNA + Ambiguity Codes
+	Protein       Amino Acide single-letter Code
+	Unlimit       Self-defined, including all 26 English letters
 */
 var (
 	DNA          *Alphabet
@@ -345,11 +345,11 @@ var (
 	Protein      *Alphabet
 	Unlimit      *Alphabet
 
-	abProtein      map[byte]bool
-	abDNAredundant map[byte]bool
-	abDNA          map[byte]bool
-	abRNAredundant map[byte]bool
-	abRNA          map[byte]bool
+	abProtein      asciiset.ASCIISet
+	abDNAredundant asciiset.ASCIISet
+	abDNA          asciiset.ASCIISet
+	abRNAredundant asciiset.ASCIISet
+	abRNA          asciiset.ASCIISet
 )
 
 func init() {
@@ -417,7 +417,7 @@ func GuessAlphabet(seqs []byte) *Alphabet {
 	if len(seqs) == 0 {
 		return Unlimit
 	}
-	var alphabetMap map[byte]bool
+	var alphabetMap asciiset.ASCIISet
 	if AlphabetGuessSeqLengthThreshold == 0 || len(seqs) <= AlphabetGuessSeqLengthThreshold {
 		alphabetMap = slice2map(byteutil.Alphabet(seqs))
 	} else { // reduce guessing time
@@ -454,19 +454,14 @@ func GuessAlphabetLessConservatively(seqs []byte) *Alphabet {
 	return ab
 }
 
-func isSubset(query, subject map[byte]bool) bool {
-	for b := range query {
-		if _, ok := subject[b]; !ok {
-			return false
-		}
-	}
-	return true
+// isSubset returns true if query is a subset of subject
+func isSubset(query, subject asciiset.ASCIISet) bool {
+	// A ⊆ B iff (A ∪ B) = B
+	var union = query.Union(subject)
+	return union.Equals(subject)
 }
 
-func slice2map(s []byte) map[byte]bool {
-	m := make(map[byte]bool)
-	for _, b := range s {
-		m[b] = true
-	}
+func slice2map(s []byte) asciiset.ASCIISet {
+	m, _ := asciiset.MakeASCIISet(string(s))
 	return m
 }

--- a/seq/alphabet.go
+++ b/seq/alphabet.go
@@ -457,7 +457,7 @@ func GuessAlphabetLessConservatively(seqs []byte) *Alphabet {
 // isSubset returns true if query is a subset of subject
 func isSubset(query, subject asciiset.ASCIISet) bool {
 	// A ⊆ B iff (A ∪ B) = B
-	var union = query.Union(subject)
+	union := query.Union(subject)
 	return union.Equals(subject)
 }
 


### PR DESCRIPTION
Proposing use of `ASCIISet` instead of `map[byte]bool`.

`ASCIISet` is a zero-dependency library for sets of ASCII characters with [28 times faster lookup speed](https://github.com/elliotwutingfeng/asciiset#results) than `map[byte]bool`.